### PR TITLE
feat(infra): database schema — sources, tickets, ticket_events

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -6,11 +6,10 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from app.core.config import settings
-from app.core.database import Base
-
 # Import all models here so Alembic can detect them
 import app.models  # noqa: F401
+from app.core.config import settings
+from app.core.database import Base
 
 config = context.config
 if config.config_file_name is not None:

--- a/api/alembic/versions/001_create_sources_table.py
+++ b/api/alembic/versions/001_create_sources_table.py
@@ -1,0 +1,41 @@
+"""create sources table
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-18
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sources",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(100), nullable=False),
+        sa.Column("api_key_hash", sa.String(255), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("slug", name="uq_sources_slug"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("sources")

--- a/api/alembic/versions/002_create_tickets_table.py
+++ b/api/alembic/versions/002_create_tickets_table.py
@@ -1,0 +1,65 @@
+"""create tickets table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-18
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tickets",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "source_id",
+            sa.Integer(),
+            sa.ForeignKey("sources.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("external_id", sa.String(100), nullable=False),
+        sa.Column("type", sa.String(50), nullable=True),
+        sa.Column("priority", sa.String(50), nullable=True),
+        sa.Column("status", sa.String(100), nullable=False),
+        sa.Column("subject", sa.String(500), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("source_metadata", JSONB(), nullable=True),
+        sa.Column("source_created_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("source_updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "first_ingested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "last_synced_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("source_id", "external_id", name="uq_ticket_source_external"),
+    )
+    op.create_index("ix_tickets_source_id", "tickets", ["source_id"])
+    op.create_index("ix_tickets_status", "tickets", ["status"])
+    op.create_index("ix_tickets_priority", "tickets", ["priority"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tickets_priority", "tickets")
+    op.drop_index("ix_tickets_status", "tickets")
+    op.drop_index("ix_tickets_source_id", "tickets")
+    op.drop_table("tickets")

--- a/api/alembic/versions/003_create_ticket_events_table.py
+++ b/api/alembic/versions/003_create_ticket_events_table.py
@@ -1,0 +1,49 @@
+"""create ticket_events table
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-03-18
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "ticket_id",
+            sa.Integer(),
+            sa.ForeignKey("tickets.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(100), nullable=False),
+        sa.Column("payload", JSONB(), nullable=True),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_ticket_events_ticket_id", "ticket_events", ["ticket_id"])
+    op.create_index("ix_ticket_events_occurred_at", "ticket_events", ["occurred_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_events_occurred_at", "ticket_events")
+    op.drop_index("ix_ticket_events_ticket_id", "ticket_events")
+    op.drop_table("ticket_events")

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,0 +1,5 @@
+from app.models.source import Source
+from app.models.ticket import Ticket
+from app.models.ticket_event import TicketEvent
+
+__all__ = ["Source", "Ticket", "TicketEvent"]

--- a/api/app/models/source.py
+++ b/api/app/models/source.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.ticket import Ticket
+
+from sqlalchemy import Boolean, DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class Source(Base):
+    __tablename__ = "sources"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    api_key_hash: Mapped[str] = mapped_column(String(255), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    tickets: Mapped[list[Ticket]] = relationship("Ticket", back_populates="source")

--- a/api/app/models/ticket.py
+++ b/api/app/models/ticket.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.source import Source
+    from app.models.ticket_event import TicketEvent
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class Ticket(Base):
+    __tablename__ = "tickets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    source_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("sources.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+
+    # Identity in the source system (e.g. "SUP-2026-0042")
+    external_id: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    # Normalised fields — mapped from source system values
+    type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    priority: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    subject: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Raw payload from source — preserved without modification
+    source_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Timestamps from the source system
+    source_created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    source_updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Aegis-managed timestamps
+    first_ingested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_synced_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    source: Mapped[Source] = relationship("Source", back_populates="tickets")
+    events: Mapped[list[TicketEvent]] = relationship(
+        "TicketEvent", back_populates="ticket", order_by="TicketEvent.occurred_at"
+    )
+
+    __table_args__ = (
+        # Unique ticket per source — prevents duplicate ingestion
+        UniqueConstraint("source_id", "external_id", name="uq_ticket_source_external"),
+    )

--- a/api/app/models/ticket_event.py
+++ b/api/app/models/ticket_event.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.models.ticket import Ticket
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+
+
+class TicketEvent(Base):
+    __tablename__ = "ticket_events"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ticket_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    # e.g. "created", "status_changed", "response_added", "assigned"
+    event_type: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    # Full raw payload as received from the source system
+    payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # When the event occurred in the source system (may differ from ingestion time)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    ticket: Mapped[Ticket] = relationship("Ticket", back_populates="events")


### PR DESCRIPTION
## Summary

- **Source** model: name, slug, api_key_hash, is_active
- **Ticket** model: normalised fields + `source_metadata` JSONB for raw source payload. `UniqueConstraint(source_id, external_id)` ensures idempotent ingestion
- **TicketEvent** model: append-only event log per ticket

3 Alembic migrations (written manually — no DB connection required to generate):
- `001` sources, `002` tickets (+ 3 indexes), `003` ticket_events (+ 2 indexes)

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest` 1 passed

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)