### PR TITLE
feat(api): source management — register sources and API key auth

### DIFF
--- a/api/app/core/auth.py
+++ b/api/app/core/auth.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+from app.core.dependencies import DbSession
+from app.models.source import Source
+from app.services.source_service import SourceService
+
+_api_key_header = APIKeyHeader(name="X-Aegis-Key", auto_error=False)
+
+
+async def get_current_source(
+    db: DbSession,
+    api_key: Annotated[str | None, Security(_api_key_header)] = None,
+) -> Source:
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="X-Aegis-Key header is required",
+        )
+    source = await SourceService(db).get_by_api_key(api_key)
+    if source is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or inactive API key",
+        )
+    return source
+
+
+CurrentSource = Annotated[Source, Depends(get_current_source)]

--- a/api/app/core/security.py
+++ b/api/app/core/security.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+
+
+def generate_api_key() -> str:
+    """Generate a cryptographically secure API key (shown once to the user)."""
+    return secrets.token_urlsafe(32)
+
+
+def hash_api_key(key: str) -> str:
+    """Hash an API key with SHA-256. High-entropy tokens don't need bcrypt."""
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+def verify_api_key(plain: str, hashed: str) -> bool:
+    return hmac.compare_digest(hash_api_key(plain), hashed)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.core.config import settings
+from app.routers import sources
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -28,6 +29,9 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+
+app.include_router(sources.router)
 
 
 @app.get("/health")

--- a/api/app/routers/sources.py
+++ b/api/app/routers/sources.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy.exc import IntegrityError
+
+from app.core.dependencies import DbSession
+from app.schemas.source import SourceCreate, SourceCreatedResponse, SourceResponse
+from app.services.source_service import SourceService
+
+router = APIRouter(prefix="/v1/sources", tags=["sources"])
+
+
+@router.post("", status_code=status.HTTP_201_CREATED, response_model=SourceCreatedResponse)
+async def create_source(data: SourceCreate, db: DbSession) -> SourceCreatedResponse:
+    """Register a new source. Returns the API key — store it securely, it won't be shown again."""
+    try:
+        source, plain_key = await SourceService(db).create(data)
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A source with slug '{data.slug}' already exists",
+        ) from exc
+    return SourceCreatedResponse(
+        id=source.id,
+        name=source.name,
+        slug=source.slug,
+        is_active=source.is_active,
+        created_at=source.created_at,
+        api_key=plain_key,
+    )
+
+
+@router.get("", response_model=list[SourceResponse])
+async def list_sources(db: DbSession) -> list[SourceResponse]:
+    sources = await SourceService(db).list_all()
+    return [SourceResponse.model_validate(s) for s in sources]

--- a/api/app/schemas/source.py
+++ b/api/app/schemas/source.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SourceCreate(BaseModel):
+    name: str = Field(..., min_length=2, max_length=255)
+    slug: str = Field(..., min_length=2, max_length=100, pattern=r"^[a-z0-9-]+$")
+
+
+class SourceResponse(BaseModel):
+    id: int
+    name: str
+    slug: str
+    is_active: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SourceCreatedResponse(SourceResponse):
+    """Returned only once at creation — includes the plaintext API key."""
+
+    api_key: str

--- a/api/app/services/source_service.py
+++ b/api/app/services/source_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import generate_api_key, hash_api_key, verify_api_key
+from app.models.source import Source
+from app.schemas.source import SourceCreate
+
+
+class SourceService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def create(self, data: SourceCreate) -> tuple[Source, str]:
+        """Create a source and return (source, plaintext_api_key)."""
+        plain_key = generate_api_key()
+        source = Source(
+            name=data.name,
+            slug=data.slug,
+            api_key_hash=hash_api_key(plain_key),
+        )
+        self._db.add(source)
+        await self._db.commit()
+        await self._db.refresh(source)
+        return source, plain_key
+
+    async def list_all(self) -> list[Source]:
+        result = await self._db.execute(select(Source).order_by(Source.created_at.desc()))
+        return list(result.scalars().all())
+
+    async def get_by_api_key(self, plain_key: str) -> Source | None:
+        """Validate an API key and return the active source, or None."""
+        result = await self._db.execute(select(Source).where(Source.is_active.is_(True)))
+        for source in result.scalars().all():
+            if verify_api_key(plain_key, source.api_key_hash):
+                return source
+        return None

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,5 +6,4 @@ asyncpg>=0.29.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 python-jose[cryptography]>=3.3.0
-passlib[bcrypt]>=1.7.4
 httpx>=0.27.0

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,8 +2,26 @@ from __future__ import annotations
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
 
+from app.core.config import settings
+from app.core.database import get_db
 from app.main import app
+
+# NullPool: no connection reuse between tests — avoids event loop conflicts
+_test_engine = create_async_engine(settings.database_url, poolclass=NullPool)
+_TestSession = async_sessionmaker(
+    bind=_test_engine, expire_on_commit=False, autocommit=False, autoflush=False
+)
+
+
+async def _override_get_db() -> AsyncSession:  # type: ignore[override]
+    async with _TestSession() as session:
+        yield session
+
+
+app.dependency_overrides[get_db] = _override_get_db
 
 
 @pytest.fixture

--- a/api/tests/test_sources.py
+++ b/api/tests/test_sources.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+def unique_slug(prefix: str = "test") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.asyncio
+async def test_create_source(client: AsyncClient) -> None:
+    slug = unique_slug("gestao-frota")
+    response = await client.post(
+        "/v1/sources",
+        json={"name": "gestao frota Cliente A", "slug": slug},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["slug"] == slug
+    assert "api_key" in data
+    assert len(data["api_key"]) > 20
+
+
+@pytest.mark.asyncio
+async def test_create_source_duplicate_slug(client: AsyncClient) -> None:
+    slug = unique_slug("source")
+    payload = {"name": "Source X", "slug": slug}
+    r1 = await client.post("/v1/sources", json=payload)
+    assert r1.status_code == 201
+    r2 = await client.post("/v1/sources", json=payload)
+    assert r2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_list_sources(client: AsyncClient) -> None:
+    await client.post("/v1/sources", json={"name": "Source A", "slug": unique_slug("a")})
+    await client.post("/v1/sources", json={"name": "Source B", "slug": unique_slug("b")})
+    response = await client.get("/v1/sources")
+    assert response.status_code == 200
+    assert len(response.json()) >= 2
+
+
+@pytest.mark.asyncio
+async def test_ingest_requires_api_key(client: AsyncClient) -> None:
+    response = await client.post("/v1/ingest/tickets", json={})
+    assert response.status_code in (401, 404)


### PR DESCRIPTION
## Summary

- `POST /v1/sources` — register a new source, returns API key (shown once)
- `GET /v1/sources` — list all registered sources
- `X-Aegis-Key` header auth dependency (`CurrentSource`) ready for ingest routes
- API key hashed with SHA-256 + `hmac.compare_digest` (bcrypt dropped — inappropriate for high-entropy tokens and broken on Python 3.14)
- `NullPool` in test engine to avoid asyncpg event loop conflicts between tests

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean  
- [x] 5/5 tests passing

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)