### PR TITLE
feat(api): ingest API — POST /v1/ingest/tickets and events

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.core.config import settings
-from app.routers import sources
+from app.routers import ingest, sources
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -32,6 +32,7 @@ app = FastAPI(
 
 
 app.include_router(sources.router)
+app.include_router(ingest.router)
 
 
 @app.get("/health")

--- a/api/app/routers/ingest.py
+++ b/api/app/routers/ingest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, status
+
+from app.core.auth import CurrentSource
+from app.core.dependencies import DbSession
+from app.schemas.ingest import IngestResponse, TicketEventPayload, TicketIngestPayload
+from app.services.ingest_service import IngestService
+
+router = APIRouter(prefix="/v1/ingest", tags=["ingest"])
+
+
+@router.post(
+    "/tickets",
+    status_code=status.HTTP_200_OK,
+    response_model=IngestResponse,
+    summary="Ingest or update a ticket from a source system",
+)
+async def ingest_ticket(
+    data: TicketIngestPayload,
+    source: CurrentSource,
+    db: DbSession,
+) -> IngestResponse:
+    """
+    Idempotent upsert: if `external_id` already exists for this source, the ticket
+    is updated. Otherwise a new ticket is created and 201 is returned implicitly via
+    the `created` flag in the response body.
+    """
+    ticket, created = await IngestService(db).upsert_ticket(source, data)
+    return IngestResponse(
+        ticket_id=ticket.id,
+        external_id=ticket.external_id,
+        created=created,
+    )
+
+
+@router.post(
+    "/tickets/events",
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a discrete ticket event from a source system",
+)
+async def ingest_ticket_event(
+    data: TicketEventPayload,
+    source: CurrentSource,
+    db: DbSession,
+) -> dict[str, int]:
+    event = await IngestService(db).record_event(source, data)
+    return {"event_id": event.id}

--- a/api/app/schemas/ingest.py
+++ b/api/app/schemas/ingest.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TicketIngestPayload(BaseModel):
+    """Payload sent by an external system when a ticket is created or updated."""
+
+    external_id: str = Field(..., min_length=1, max_length=100)
+    type: str | None = Field(None, max_length=50)
+    priority: str | None = Field(None, max_length=50)
+    status: str = Field(..., max_length=100)
+    subject: str = Field(..., min_length=1, max_length=500)
+    description: str | None = None
+    source_metadata: dict | None = None
+    source_created_at: datetime | None = None
+    source_updated_at: datetime | None = None
+
+
+class TicketEventPayload(BaseModel):
+    """Payload sent when a ticket state changes in the source system."""
+
+    external_id: str = Field(..., min_length=1, max_length=100)
+    event_type: str = Field(..., max_length=100)
+    payload: dict | None = None
+    occurred_at: datetime | None = None
+
+
+class IngestResponse(BaseModel):
+    ticket_id: int
+    external_id: str
+    created: bool  # True = new ticket, False = updated existing

--- a/api/app/services/ingest_service.py
+++ b/api/app/services/ingest_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.source import Source
+from app.models.ticket import Ticket
+from app.models.ticket_event import TicketEvent
+from app.schemas.ingest import TicketEventPayload, TicketIngestPayload
+
+
+class IngestService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def upsert_ticket(self, source: Source, data: TicketIngestPayload) -> tuple[Ticket, bool]:
+        """
+        Create or update a ticket from a source payload.
+        Returns (ticket, created) where created=True means a new ticket was inserted.
+        """
+        result = await self._db.execute(
+            select(Ticket).where(
+                Ticket.source_id == source.id,
+                Ticket.external_id == data.external_id,
+            )
+        )
+        ticket = result.scalar_one_or_none()
+
+        if ticket is None:
+            ticket = Ticket(
+                source_id=source.id,
+                external_id=data.external_id,
+                type=data.type,
+                priority=data.priority,
+                status=data.status,
+                subject=data.subject,
+                description=data.description,
+                source_metadata=data.source_metadata,
+                source_created_at=data.source_created_at,
+                source_updated_at=data.source_updated_at,
+            )
+            self._db.add(ticket)
+            await self._db.flush()  # get the id without committing
+
+            # Record the creation event
+            self._db.add(
+                TicketEvent(
+                    ticket_id=ticket.id,
+                    event_type="created",
+                    payload=data.model_dump(mode="json"),
+                    occurred_at=data.source_created_at or datetime.now(UTC),
+                )
+            )
+            await self._db.commit()
+            await self._db.refresh(ticket)
+            return ticket, True
+
+        # Update existing ticket
+        ticket.status = data.status
+        ticket.priority = data.priority
+        ticket.type = data.type
+        ticket.subject = data.subject
+        ticket.description = data.description
+        ticket.source_metadata = data.source_metadata
+        ticket.source_updated_at = data.source_updated_at
+        ticket.last_synced_at = datetime.now(UTC)
+
+        self._db.add(
+            TicketEvent(
+                ticket_id=ticket.id,
+                event_type="synced",
+                payload=data.model_dump(mode="json"),
+                occurred_at=data.source_updated_at or datetime.now(UTC),
+            )
+        )
+        await self._db.commit()
+        await self._db.refresh(ticket)
+        return ticket, False
+
+    async def record_event(self, source: Source, data: TicketEventPayload) -> TicketEvent:
+        """
+        Record a discrete event (status change, response added, etc.) for an existing ticket.
+        Creates the ticket if it doesn't exist yet (defensive — source may send events before
+        the initial ingest in rare race conditions).
+        """
+        result = await self._db.execute(
+            select(Ticket).where(
+                Ticket.source_id == source.id,
+                Ticket.external_id == data.external_id,
+            )
+        )
+        ticket = result.scalar_one_or_none()
+
+        if ticket is None:
+            # Defensive: create a minimal ticket record
+            ticket = Ticket(
+                source_id=source.id,
+                external_id=data.external_id,
+                status="unknown",
+                subject=f"[auto-created from event] {data.external_id}",
+            )
+            self._db.add(ticket)
+            await self._db.flush()
+
+        event = TicketEvent(
+            ticket_id=ticket.id,
+            event_type=data.event_type,
+            payload=data.payload,
+            occurred_at=data.occurred_at or datetime.now(UTC),
+        )
+        self._db.add(event)
+        await self._db.commit()
+        await self._db.refresh(event)
+        return event

--- a/api/tests/test_ingest.py
+++ b/api/tests/test_ingest.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+def unique_slug() -> str:
+    return f"src-{uuid.uuid4().hex[:8]}"
+
+
+def unique_external_id() -> str:
+    return f"SUP-2026-{uuid.uuid4().hex[:6].upper()}"
+
+
+@pytest.fixture
+async def source_with_key(client: AsyncClient) -> dict:
+    """Create a source and return its data including the plaintext API key."""
+    resp = await client.post(
+        "/v1/sources",
+        json={"name": "Test Source", "slug": unique_slug()},
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.mark.asyncio
+async def test_ingest_ticket_created(client: AsyncClient, source_with_key: dict) -> None:
+    external_id = unique_external_id()
+    response = await client.post(
+        "/v1/ingest/tickets",
+        headers={"X-Aegis-Key": source_with_key["api_key"]},
+        json={
+            "external_id": external_id,
+            "type": "bug",
+            "priority": "high",
+            "status": "open",
+            "subject": "Error on vehicle checkout",
+            "description": "Crash when submitting the form.",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["external_id"] == external_id
+    assert data["created"] is True
+
+
+@pytest.mark.asyncio
+async def test_ingest_ticket_upsert(client: AsyncClient, source_with_key: dict) -> None:
+    """Second ingest of the same external_id should update, not create."""
+    external_id = unique_external_id()
+    headers = {"X-Aegis-Key": source_with_key["api_key"]}
+    payload = {
+        "external_id": external_id,
+        "type": "bug",
+        "priority": "high",
+        "status": "open",
+        "subject": "Initial subject",
+    }
+
+    r1 = await client.post("/v1/ingest/tickets", headers=headers, json=payload)
+    assert r1.json()["created"] is True
+
+    payload["status"] = "in_progress"
+    payload["subject"] = "Updated subject"
+    r2 = await client.post("/v1/ingest/tickets", headers=headers, json=payload)
+    assert r2.status_code == 200
+    assert r2.json()["created"] is False
+    assert r2.json()["ticket_id"] == r1.json()["ticket_id"]
+
+
+@pytest.mark.asyncio
+async def test_ingest_requires_valid_api_key(client: AsyncClient) -> None:
+    response = await client.post(
+        "/v1/ingest/tickets",
+        headers={"X-Aegis-Key": "invalid-key"},
+        json={
+            "external_id": "SUP-2026-001",
+            "status": "open",
+            "subject": "Test",
+        },
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_ingest_event(client: AsyncClient, source_with_key: dict) -> None:
+    external_id = unique_external_id()
+    headers = {"X-Aegis-Key": source_with_key["api_key"]}
+
+    # Create the ticket first
+    await client.post(
+        "/v1/ingest/tickets",
+        headers=headers,
+        json={"external_id": external_id, "status": "open", "subject": "Test ticket"},
+    )
+
+    # Send a status change event
+    response = await client.post(
+        "/v1/ingest/tickets/events",
+        headers=headers,
+        json={
+            "external_id": external_id,
+            "event_type": "status_changed",
+            "payload": {"from": "open", "to": "in_progress"},
+        },
+    )
+    assert response.status_code == 201
+    assert "event_id" in response.json()


### PR DESCRIPTION
## Summary

- `POST /v1/ingest/tickets` — idempotent upsert by `(source_id, external_id)`. Returns `{ticket_id, external_id, created: bool}`. Records a `created` or `synced` event automatically on each call.
- `POST /v1/ingest/tickets/events` — records a discrete event (`status_changed`, `response_added`, etc.) for an existing ticket. Defensive auto-creation if ticket not found (race condition guard).
- Both routes require `X-Aegis-Key` header — unauthorized requests get 401.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] 9/9 tests passing (4 new ingest tests)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)