### PR TITLE
feat(api): ticket read API — list with filters and detail

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,7 +7,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.core.config import settings
-from app.routers import ingest, sources
+from app.routers import ingest, sources, tickets
 
 logging.basicConfig(
     level=logging.DEBUG if settings.debug else logging.INFO,
@@ -33,6 +33,7 @@ app = FastAPI(
 
 app.include_router(sources.router)
 app.include_router(ingest.router)
+app.include_router(tickets.router)
 
 
 @app.get("/health")

--- a/api/app/routers/tickets.py
+++ b/api/app/routers/tickets.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from app.core.dependencies import DbSession
+from app.schemas.ticket import TicketDetailResponse, TicketListResponse, TicketResponse
+from app.services.ticket_service import TicketService
+
+router = APIRouter(prefix="/v1/tickets", tags=["tickets"])
+
+
+@router.get("", response_model=TicketListResponse)
+async def list_tickets(
+    db: DbSession,
+    source_id: int | None = Query(None),
+    status: str | None = Query(None),
+    priority: str | None = Query(None),
+    type: str | None = Query(None),
+    created_after: datetime | None = Query(None),
+    created_before: datetime | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> TicketListResponse:
+    tickets, total = await TicketService(db).list_tickets(
+        source_id=source_id,
+        status=status,
+        priority=priority,
+        type=type,
+        created_after=created_after,
+        created_before=created_before,
+        limit=limit,
+        offset=offset,
+    )
+
+    items = []
+    for t in tickets:
+        items.append(
+            TicketResponse(
+                id=t.id,
+                source_id=t.source_id,
+                source_name=t.source.name if t.source else "",
+                external_id=t.external_id,
+                type=t.type,
+                priority=t.priority,
+                status=t.status,
+                subject=t.subject,
+                description=t.description,
+                source_metadata=t.source_metadata,
+                source_created_at=t.source_created_at,
+                source_updated_at=t.source_updated_at,
+                first_ingested_at=t.first_ingested_at,
+                last_synced_at=t.last_synced_at,
+            )
+        )
+
+    return TicketListResponse(items=items, total=total, limit=limit, offset=offset)
+
+
+@router.get("/{ticket_id}", response_model=TicketDetailResponse)
+async def get_ticket(ticket_id: int, db: DbSession) -> TicketDetailResponse:
+    ticket = await TicketService(db).get_ticket(ticket_id)
+    if ticket is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+
+    return TicketDetailResponse(
+        id=ticket.id,
+        source_id=ticket.source_id,
+        source_name=ticket.source.name if ticket.source else "",
+        external_id=ticket.external_id,
+        type=ticket.type,
+        priority=ticket.priority,
+        status=ticket.status,
+        subject=ticket.subject,
+        description=ticket.description,
+        source_metadata=ticket.source_metadata,
+        source_created_at=ticket.source_created_at,
+        source_updated_at=ticket.source_updated_at,
+        first_ingested_at=ticket.first_ingested_at,
+        last_synced_at=ticket.last_synced_at,
+        events=[
+            {
+                "id": e.id,
+                "event_type": e.event_type,
+                "payload": e.payload,
+                "occurred_at": e.occurred_at,
+            }
+            for e in ticket.events
+        ],
+    )

--- a/api/app/schemas/ticket.py
+++ b/api/app/schemas/ticket.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class TicketEventResponse(BaseModel):
+    id: int
+    event_type: str
+    payload: dict | None
+    occurred_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TicketResponse(BaseModel):
+    id: int
+    source_id: int
+    source_name: str
+    external_id: str
+    type: str | None
+    priority: str | None
+    status: str
+    subject: str
+    description: str | None
+    source_metadata: dict | None
+    source_created_at: datetime | None
+    source_updated_at: datetime | None
+    first_ingested_at: datetime
+    last_synced_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TicketDetailResponse(TicketResponse):
+    events: list[TicketEventResponse]
+
+
+class TicketListResponse(BaseModel):
+    items: list[TicketResponse]
+    total: int
+    limit: int
+    offset: int

--- a/api/app/services/ticket_service.py
+++ b/api/app/services/ticket_service.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.source import Source  # noqa: F401 — loaded via selectinload
+from app.models.ticket import Ticket
+from app.models.ticket_event import TicketEvent  # noqa: F401 — loaded via selectinload
+
+
+class TicketService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_tickets(
+        self,
+        *,
+        source_id: int | None = None,
+        status: str | None = None,
+        priority: str | None = None,
+        type: str | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[Ticket], int]:
+        query = select(Ticket)
+
+        if source_id is not None:
+            query = query.where(Ticket.source_id == source_id)
+        if status is not None:
+            query = query.where(Ticket.status == status)
+        if priority is not None:
+            query = query.where(Ticket.priority == priority)
+        if type is not None:
+            query = query.where(Ticket.type == type)
+        if created_after is not None:
+            query = query.where(Ticket.first_ingested_at >= created_after)
+        if created_before is not None:
+            query = query.where(Ticket.first_ingested_at <= created_before)
+
+        count_result = await self._db.execute(select(func.count()).select_from(query.subquery()))
+        total = count_result.scalar_one()
+
+        result = await self._db.execute(
+            query.options(selectinload(Ticket.source))
+            .order_by(Ticket.first_ingested_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        tickets = list(result.scalars().all())
+        return tickets, total
+
+    async def get_ticket(self, ticket_id: int) -> Ticket | None:
+        result = await self._db.execute(
+            select(Ticket)
+            .where(Ticket.id == ticket_id)
+            .options(selectinload(Ticket.source), selectinload(Ticket.events))
+        )
+        return result.scalar_one_or_none()

--- a/api/tests/test_tickets.py
+++ b/api/tests/test_tickets.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+def unique_slug() -> str:
+    return f"src-{uuid.uuid4().hex[:8]}"
+
+
+def unique_external_id() -> str:
+    return f"SUP-2026-{uuid.uuid4().hex[:6].upper()}"
+
+
+@pytest.fixture
+async def source_with_key(client: AsyncClient) -> dict:
+    resp = await client.post(
+        "/v1/sources",
+        json={"name": "Ticket Read Test Source", "slug": unique_slug()},
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+@pytest.fixture
+async def ingested_ticket(client: AsyncClient, source_with_key: dict) -> dict:
+    """Ingest a ticket and return {ticket_id, external_id, api_key, source_id}."""
+    external_id = unique_external_id()
+    resp = await client.post(
+        "/v1/ingest/tickets",
+        headers={"X-Aegis-Key": source_with_key["api_key"]},
+        json={
+            "external_id": external_id,
+            "type": "bug",
+            "priority": "high",
+            "status": "open",
+            "subject": "Vehicle checkout crash",
+            "description": "Crash when submitting form.",
+        },
+    )
+    assert resp.status_code == 200
+    return {
+        "ticket_id": resp.json()["ticket_id"],
+        "external_id": external_id,
+        "api_key": source_with_key["api_key"],
+        "source_id": source_with_key["id"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_tickets(client: AsyncClient, ingested_ticket: dict) -> None:
+    response = await client.get("/v1/tickets")
+    assert response.status_code == 200
+    data = response.json()
+    assert "items" in data
+    assert "total" in data
+    assert data["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_list_tickets_filter_by_source(client: AsyncClient, ingested_ticket: dict) -> None:
+    response = await client.get("/v1/tickets", params={"source_id": ingested_ticket["source_id"]})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    for item in data["items"]:
+        assert item["source_id"] == ingested_ticket["source_id"]
+
+
+@pytest.mark.asyncio
+async def test_list_tickets_filter_by_status(client: AsyncClient, ingested_ticket: dict) -> None:
+    response = await client.get("/v1/tickets", params={"status": "open"})
+    assert response.status_code == 200
+    for item in response.json()["items"]:
+        assert item["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_detail(client: AsyncClient, ingested_ticket: dict) -> None:
+    response = await client.get(f"/v1/tickets/{ingested_ticket['ticket_id']}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == ingested_ticket["ticket_id"]
+    assert data["external_id"] == ingested_ticket["external_id"]
+    assert "events" in data
+    assert len(data["events"]) >= 1
+    assert data["events"][0]["event_type"] == "created"
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_not_found(client: AsyncClient) -> None:
+    response = await client.get("/v1/tickets/999999")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_tickets_pagination(client: AsyncClient, ingested_ticket: dict) -> None:
+    response = await client.get("/v1/tickets", params={"limit": 1, "offset": 0})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) <= 1
+    assert data["limit"] == 1


### PR DESCRIPTION
## Summary

- `GET /v1/tickets` — paginated list with filters: `source_id`, `status`, `priority`, `type`, `created_after`, `created_before`, `limit`, `offset`. Returns `{items, total, limit, offset}`.
- `GET /v1/tickets/{id}` — ticket detail with full event history (eager loaded via `selectinload`)
- `source_name` resolved from the Source relationship in both endpoints

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] 15/15 tests passing (6 new ticket read tests)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)